### PR TITLE
pythonize fixing of broken env var scripts in impi easyblock

### DIFF
--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -134,7 +134,7 @@ EULA=accept
             # fix broken env scripts after the move
             for script in [os.path.join('intel64', 'bin', 'mpivars.csh'), os.path.join('mic', 'bin', 'mpivars.csh')]:
                 for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.eb'):
-                    line = re.sub(r"^setenv I_MPI_ROOT.*", "setenv I_MPI_ROOT=%s" % self.installdir, line)
+                    line = re.sub(r"^setenv I_MPI_ROOT.*", "setenv I_MPI_ROOT %s" % self.installdir, line)
                     sys.stdout.write(line)
             for script in [os.path.join('intel64', 'bin', 'mpivars.sh'), os.path.join('mic', 'bin', 'mpivars.sh')]:
                 for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.eb'):

--- a/easybuild/easyblocks/i/impi.py
+++ b/easybuild/easyblocks/i/impi.py
@@ -31,9 +31,10 @@ EasyBuild support for installing the Intel MPI library, implemented as an easybl
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
-
+import fileinput
 import os
-import shutil
+import re
+import sys
 from distutils.version import LooseVersion
 
 from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
@@ -80,18 +81,6 @@ class EB_impi(IntelBase):
             # impi v4.1.1 and v5.0.1 installers create impi/<version> subdir, so stuff needs to be moved afterwards
             if impiver == LooseVersion('4.1.1.036') or impiver >= LooseVersion('5.0.1.035'):
                 super(EB_impi, self).move_after_install()
-                # Fix broken env scripts after the move
-                for script in ['intel64/bin/mpivars.csh', 'mic/bin/mpivars.csh']:
-                    self.cfg.update(
-                        'postinstallcmds',
-                        ["sed -i '/setenv I_MPI_ROOT/c\setenv I_MPI_ROOT=%%(installdir)s' %%(installdir)s/%s" % script]
-                        )
-                for script in ['intel64/bin/mpivars.sh', 'mic/bin/mpivars.sh']:
-                    self.cfg.update(
-                        'postinstallcmds',
-                        ["sed -i '/I_MPI_ROOT=/c\I_MPI_ROOT=%%(installdir)s; export I_MPI_ROOT' %%(installdir)s/%s" \
-                        % script]
-                        )
         else:
             # impi up until version 4.0.0.x uses custom installation procedure.
             silent = \
@@ -135,6 +124,22 @@ EULA=accept
 
             cmd = "./install.sh --tmp-dir=%s --silent=%s" % (tmpdir, silentcfg)
             run_cmd(cmd, log_all=True, simple=True)
+
+    def post_install_step(self):
+        """Custom post install step for IMPI, fix broken env scripts after moving installed files."""
+        super(EB_impi, self).post_install_step()
+
+        impiver = LooseVersion(self.version)
+        if impiver == LooseVersion('4.1.1.036') or impiver >= LooseVersion('5.0.1.035'):
+            # fix broken env scripts after the move
+            for script in [os.path.join('intel64', 'bin', 'mpivars.csh'), os.path.join('mic', 'bin', 'mpivars.csh')]:
+                for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.eb'):
+                    line = re.sub(r"^setenv I_MPI_ROOT.*", "setenv I_MPI_ROOT=%s" % self.installdir, line)
+                    sys.stdout.write(line)
+            for script in [os.path.join('intel64', 'bin', 'mpivars.sh'), os.path.join('mic', 'bin', 'mpivars.sh')]:
+                for line in fileinput.input(os.path.join(self.installdir, script), inplace=1, backup='.orig.eb'):
+                    line = re.sub(r"^I_MPI_ROOT=", "I_MPI_ROOT=%s; export I_MPI_ROOT" % self.installdir, line)
+                    sys.stdout.write(line)
 
     def sanity_check_step(self):
         """Custom sanity check paths for IMPI."""


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyblocks/pull/629

already tested on affected impi versions, works as expected:

```
$ diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/bin64: mpdlib.pyc
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/bin64: mpdman.pyc
diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/bin64/mpivars.csh /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/bin64/mpivars.csh
--- /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/bin64/mpivars.csh 2014-12-12 01:05:32.217741000 +0100
+++ /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/bin64/mpivars.csh  2015-07-14 10:44:47.067180000 +0200
@@ -19,7 +19,7 @@
 # Intel in writing.
 #

-setenv I_MPI_ROOT /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044
+setenv I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2

 if !($?PATH) then
     setenv PATH ${I_MPI_ROOT}/intel64/bin
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/bin64: mpivars.csh.orig.eb
diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/bin64/mpivars.sh /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/bin64/mpivars.sh
--- /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/bin64/mpivars.sh  2014-12-12 01:05:32.227641000 +0100
+++ /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/bin64/mpivars.sh   2015-07-14 10:44:47.070197000 +0200
@@ -19,7 +19,7 @@
 # Intel in writing.
 #

-I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044; export I_MPI_ROOT
+I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2; export I_MPI_ROOT/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044; export I_MPI_ROOT

 if [ -z "${PATH}" ]
 then
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/bin64: mpivars.sh.orig.eb
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/easybuild: easybuild-impi-5.0.2.044-20150714.104450.log
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/easybuild: easybuild-impi-5.0.2.044-20150714.104450_test_report.md
diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/easybuild/impi-5.0.2.044-iccifort-2015.1.133-GCC-4.9.2-easybuild-devel /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/easybuild/impi-5.0.2.044-iccifort-2015.1.133-GCC-4.9.2-easybuild-devel
--- /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/easybuild/impi-5.0.2.044-iccifort-2015.1.133-GCC-4.9.2-easybuild-devel    2014-12-12 01:05:51.449192000 +0100
+++ /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/easybuild/impi-5.0.2.044-iccifort-2015.1.133-GCC-4.9.2-easybuild-devel 2015-07-14 10:44:49.649208000 +0200
@@ -1,18 +1,18 @@
 #%Module

-if { ![is-loaded icc-2015.1.133-GCC-4.9.2-easybuild-devel] } {
+if { ![ is-loaded icc-2015.1.133-GCC-4.9.2-easybuild-devel ] } {
     module load icc-2015.1.133-GCC-4.9.2-easybuild-devel
 }

-if { ![is-loaded ifort-2015.1.133-GCC-4.9.2-easybuild-devel] } {
+if { ![ is-loaded ifort-2015.1.133-GCC-4.9.2-easybuild-devel ] } {
     module load ifort-2015.1.133-GCC-4.9.2-easybuild-devel
 }

-if { ![is-loaded GCC-4.9.2-easybuild-devel] } {
+if { ![ is-loaded GCC-4.9.2-easybuild-devel ] } {
     module load GCC-4.9.2-easybuild-devel
 }

-if { ![is-loaded iccifort-2015.1.133-GCC-4.9.2-easybuild-devel] } {
+if { ![ is-loaded iccifort-2015.1.133-GCC-4.9.2-easybuild-devel ] } {
     module load iccifort-2015.1.133-GCC-4.9.2-easybuild-devel
 }
 setenv VSC_INSTITUTE_CLUSTER       "muk"
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/easybuild: impi-5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.eb
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/intel64/bin: mpdlib.pyc
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/intel64/bin: mpdman.pyc
diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/intel64/bin/mpivars.csh /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/intel64/bin/mpivars.csh
--- /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/intel64/bin/mpivars.csh   2014-12-12 01:05:32.217741000 +0100
+++ /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/intel64/bin/mpivars.csh    2015-07-14 10:44:47.067180000 +0200
@@ -19,7 +19,7 @@
 # Intel in writing.
 #

-setenv I_MPI_ROOT /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044
+setenv I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2

 if !($?PATH) then
     setenv PATH ${I_MPI_ROOT}/intel64/bin
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/intel64/bin: mpivars.csh.orig.eb
diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/intel64/bin/mpivars.sh /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/intel64/bin/mpivars.sh
--- /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/intel64/bin/mpivars.sh    2014-12-12 01:05:32.227641000 +0100
+++ /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/intel64/bin/mpivars.sh 2015-07-14 10:44:47.070197000 +0200
@@ -19,7 +19,7 @@
 # Intel in writing.
 #

-I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044; export I_MPI_ROOT
+I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2; export I_MPI_ROOT/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044; export I_MPI_ROOT

 if [ -z "${PATH}" ]
 then
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/intel64/bin: mpivars.sh.orig.eb
diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/mic/bin/mpivars.csh /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/mic/bin/mpivars.csh
--- /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/mic/bin/mpivars.csh   2014-12-12 01:05:32.248272000 +0100
+++ /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/mic/bin/mpivars.csh    2015-07-14 10:44:47.068959000 +0200
@@ -19,7 +19,7 @@
 # Intel in writing.
 #

-setenv I_MPI_ROOT /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044
+setenv I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2

 if !($?PATH) then
     setenv PATH ${I_MPI_ROOT}/mic/bin
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/mic/bin: mpivars.csh.orig.eb
diff -ru /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/mic/bin/mpivars.sh /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/mic/bin/mpivars.sh
--- /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2.orig/mic/bin/mpivars.sh    2014-12-12 01:05:32.257799000 +0100
+++ /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/mic/bin/mpivars.sh 2015-07-14 10:44:47.071226000 +0200
@@ -19,7 +19,7 @@
 # Intel in writing.
 #

-I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044; export I_MPI_ROOT
+I_MPI_ROOT=/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2; export I_MPI_ROOT/gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/impi/5.0.2.044; export I_MPI_ROOT

 if [ -z "${PATH}" ]
 then
Only in /gpfs/scratch/projects/project_gpilot/vsc40023/software/impi/5.0.2.044-iccifort-2015.1.133-GCC-4.9.2/mic/bin: mpivars.sh.orig.eb

```
