### PR TITLE
pass in post_install_step to avoid problems with symlinks created by GCC easyblock

### DIFF
--- a/easybuild/easyblocks/generic/systemcompiler.py
+++ b/easybuild/easyblocks/generic/systemcompiler.py
@@ -274,6 +274,10 @@ class SystemCompiler(Bundle, EB_GCC, EB_ifort):
             extras = super(SystemCompiler, self).make_module_extra(*args, **kwargs)
         return extras
 
+    def post_install_step(self, *args, **kwargs):
+        """Do nothing."""
+        pass
+
     def cleanup_step(self):
         """Do nothing."""
         pass


### PR DESCRIPTION
required for https://github.com/easybuilders/easybuild-easyblocks/pull/1106 due to recent changes in GCC easyblock (see https://github.com/easybuilders/easybuild-easyblocks/pull/1256)