### PR TITLE
fix error reporting for missing MPI compiler wrapper for impi

### DIFF
--- a/easybuild/easyblocks/generic/systemmpi.py
+++ b/easybuild/easyblocks/generic/systemmpi.py
@@ -97,8 +97,7 @@ class SystemMPI(Bundle, ConfigureMake, EB_impi):
                 mpi_c_wrapper = 'mpigcc'
                 path_to_mpi_c_wrapper = which(mpi_c_wrapper)
                 if not path_to_mpi_c_wrapper:
-                    raise EasyBuildError("Could not find suitable MPI wrapper to extract version for impi",
-                                         mpi_c_wrapper)
+                    raise EasyBuildError("Could not find suitable MPI wrapper to extract version for impi")
         else:
             mpi_c_wrapper = 'mpicc'
             path_to_mpi_c_wrapper = which(mpi_c_wrapper)


### PR DESCRIPTION
(for https://github.com/easybuilders/easybuild-easyblocks/pull/1106)

There's no `%s` in the error message, so there should be no argument either, to avoid an exception like `TypeError: not all arguments converted during string formatting` rather than seeing the actual error message.