### PR TITLE
multi-Python sanity check for Boost

### DIFF
--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -238,7 +238,7 @@ class EB_Boost(EasyBlock):
         """Install Boost by copying files to install dir."""
 
         self.log.info("Copying %s to installation dir %s", self.objdir, self.installdir)
-        if self.cfg['only_python_bindings'] and 'Python' in self.cfg['multi_deps'] and self.current_iteration > 0:
+        if self.cfg['only_python_bindings'] and 'Python' in self.cfg['multi_deps'] and self.iter_idx > 0:
             self.log.info("Main installation should already exist, only copying over missing Python libraries.")
             copy(glob.glob(os.path.join(self.objdir, 'lib', 'libboost_python*')), os.path.join(self.installdir, 'lib'))
         else:

--- a/easybuild/easyblocks/b/boost.py
+++ b/easybuild/easyblocks/b/boost.py
@@ -42,7 +42,6 @@ import fileinput
 import glob
 import os
 import re
-import shutil
 import sys
 
 import easybuild.tools.toolchain as toolchain
@@ -226,8 +225,8 @@ class EB_Boost(EasyBlock):
     def install_step(self):
         """Install Boost by copying files to install dir."""
 
-        self.log.info("Copying %s to installation dir %s" % (self.objdir, self.installdir))
-        if self.cfg['multi_deps'] and self.current_iteration > 0:
+        self.log.info("Copying %s to installation dir %s", self.objdir, self.installdir)
+        if self.cfg['only_python_bindings'] and 'Python' in self.cfg['multi_deps'] and self.current_iteration > 0:
             self.log.info("Main installation should already exist, only copying over missing Python libraries.")
             copy(glob.glob(os.path.join(self.objdir, 'lib', 'libboost_python*')), os.path.join(self.installdir, 'lib'))
         else:


### PR DESCRIPTION
@ocaisa Enhancement + fix for https://github.com/easybuilders/easybuild-easyblocks/pull/1718

This will result in checking for both `libboost_python27.so` and `libboost_python37.so` twice in each iteration of the sanity check, but that's better than only checking for one of them imho...